### PR TITLE
Query script tag by src match rather than relying on it being last in document order

### DIFF
--- a/src/assets/resources/fileupload.patch.js
+++ b/src/assets/resources/fileupload.patch.js
@@ -10,8 +10,8 @@ Craft.Uploader = (function(uploader) {
   };
 
   try {
-    var scriptTag = document.scripts[document.scripts.length - 1];
-    settings = JSON.parse(scriptTag.getAttribute('data-settings'));
+    var scriptTag = document.querySelector('script[src*="fileupload.patch.js"]');
+    settings = JSON.parse(scriptTag.dataset.settings);
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
Currently, the `fileupload.patch.js` script queries its own script tag in order to get the attached settings object by assuming it will be the last script in the document. However that is not always the case, in which case the script breaks and the Assets page is blank.

This PR changes from querying by source order to using `querySelector` to get the script by filename, which should be more reliable.